### PR TITLE
Create providers_cloud.tf

### DIFF
--- a/providers_cloud.tf
+++ b/providers_cloud.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+  #shared_config_files      = ["/Users/tf_user/.aws/conf"]
+  region                   = var.aws_region
+  #shared_credentials_files = ["~/.aws/credentials"]
+  profile                  = "vscode-user"
+}


### PR DESCRIPTION
Add provider for hashicorp terraform cloud without AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY